### PR TITLE
[MM-675]: Fixed the inconsistency among the different setting message

### DIFF
--- a/calendar/engine/settings_notifications.go
+++ b/calendar/engine/settings_notifications.go
@@ -79,6 +79,13 @@ func (s *notificationSetting) GetDependency() string {
 	return s.dependsOn
 }
 
+func (s *notificationSetting) getActionStyle(actionValue, currentValue string) string {
+	if actionValue == currentValue {
+		return "primary"
+	}
+	return "default"
+}
+
 func (s *notificationSetting) GetSlackAttachments(userID, settingHandler string, disabled bool) (*model.SlackAttachment, error) {
 	title := fmt.Sprintf("Setting: %s", s.title)
 	currentValueMessage := "Disabled"
@@ -97,7 +104,8 @@ func (s *notificationSetting) GetSlackAttachments(userID, settingHandler string,
 		currentValueMessage = fmt.Sprintf("Current value: %s", currentTextValue)
 
 		actionTrue := model.PostAction{
-			Name: "Yes",
+			Name:  "Yes",
+			Style: s.getActionStyle("true", currentValue.(string)),
 			Integration: &model.PostActionIntegration{
 				URL: settingHandler,
 				Context: map[string]interface{}{
@@ -108,7 +116,8 @@ func (s *notificationSetting) GetSlackAttachments(userID, settingHandler string,
 		}
 
 		actionFalse := model.PostAction{
-			Name: "No",
+			Name:  "No",
+			Style: s.getActionStyle("false", currentValue.(string)),
 			Integration: &model.PostActionIntegration{
 				URL: settingHandler,
 				Context: map[string]interface{}{

--- a/calendar/utils/settingspanel/bool_setting.go
+++ b/calendar/utils/settingspanel/bool_setting.go
@@ -82,6 +82,7 @@ func (s *boolSetting) getActionStyle(actionValue, currentValue string) string {
 
 func (s *boolSetting) GetSlackAttachments(userID, settingHandler string, disabled bool) (*model.SlackAttachment, error) {
 	title := fmt.Sprintf("Setting: %s", s.title)
+	currentValueMessage := "Disabled"
 
 	actions := []*model.PostAction{}
 	if !disabled {
@@ -89,6 +90,12 @@ func (s *boolSetting) GetSlackAttachments(userID, settingHandler string, disable
 		if err != nil {
 			return nil, err
 		}
+
+		currentTextValue := "No"
+		if currentValue == "true" {
+			currentTextValue = "Yes"
+		}
+		currentValueMessage = fmt.Sprintf("Current value: %s", currentTextValue)
 
 		actionTrue := model.PostAction{
 			Name:  "Yes",
@@ -116,9 +123,10 @@ func (s *boolSetting) GetSlackAttachments(userID, settingHandler string, disable
 		actions = []*model.PostAction{&actionTrue, &actionFalse}
 	}
 
+	text := fmt.Sprintf("%s\n%s", s.description, currentValueMessage)
 	sa := model.SlackAttachment{
 		Title:    title,
-		Text:     s.description,
+		Text:     text,
 		Actions:  actions,
 		Fallback: fmt.Sprintf("%s: %s", title, s.description),
 	}


### PR DESCRIPTION
### Summary
- Fixed the issue of the inconsistent setting message being posted when running `/mscalendar settings` command.

### Screenshots
#### Existing
![Screenshot from 2024-08-09 16-03-25](https://github.com/user-attachments/assets/68b621ef-b808-4a98-b648-194841297847)

#### Updated
![Screenshot from 2024-08-09 15-47-15](https://github.com/user-attachments/assets/5f5b10fe-a19b-4500-b1d2-009e616693d1)
