### PR TITLE
[MM-836]: Added server testcases for engine/calendar.go file

### DIFF
--- a/calendar/engine/calendar_test.go
+++ b/calendar/engine/calendar_test.go
@@ -1,0 +1,610 @@
+package engine
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/pkg/errors"
+
+	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/config"
+	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/engine/mock_plugin_api"
+	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/remote"
+	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/remote/mock_remote"
+	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/store"
+	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/store/mock_store"
+	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/utils/bot/mock_bot"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/stretchr/testify/require"
+)
+
+func TestViewCalendar(t *testing.T) {
+	mscalendar, mockStore, _, _, _, mockClient, _ := MockSetup(t)
+
+	mscalendar.Config = &config.Config{
+		Provider: config.ProviderConfig{
+			DisplayName:    "testDisplayName",
+			CommandTrigger: "testCommandTrigger",
+		},
+	}
+
+	now := time.Now()
+	from := now.Add(-time.Hour)
+	to := now.Add(time.Hour)
+
+	tests := []struct {
+		name       string
+		user       *User
+		setupMock  func()
+		assertions func(t *testing.T, events []*remote.Event, err error)
+	}{
+		{
+			name: "error filtering with client",
+			user: &User{
+				User:             nil,
+				MattermostUser:   &model.User{Id: "testMMID"},
+				MattermostUserID: "testMMUserID",
+			},
+			setupMock: func() {
+				mockStore.EXPECT().LoadUser(gomock.Any()).Return(nil, errors.New("error loading the user")).Times(1)
+			},
+			assertions: func(t *testing.T, events []*remote.Event, err error) {
+				require.Error(t, err)
+				require.EqualError(t, err, "It looks like your Mattermost account is not connected to testDisplayName. Please connect your account using `/testCommandTrigger connect`.: error loading the user")
+			},
+		},
+		{
+			name: "error getting calendar view",
+			user: &User{
+				User:             &store.User{Remote: &remote.User{ID: "testRemoteUserID"}},
+				MattermostUser:   &model.User{Id: "testMMID"},
+				MattermostUserID: "testMMUserID",
+			},
+			setupMock: func() {
+				mockClient.EXPECT().GetDefaultCalendarView("testRemoteUserID", from, to).Return(nil, fmt.Errorf("error getting calendar view")).Times(1)
+			},
+			assertions: func(t *testing.T, events []*remote.Event, err error) {
+				require.Error(t, err)
+				require.EqualError(t, err, "error getting calendar view")
+			},
+		},
+		{
+			name: "successful calendar view",
+			user: &User{
+				User:             &store.User{Remote: &remote.User{ID: "testRemoteUserID"}},
+				MattermostUser:   &model.User{Id: "testMMID"},
+				MattermostUserID: "testMMUserID",
+			},
+			setupMock: func() {
+				mockClient.EXPECT().GetDefaultCalendarView("testRemoteUserID", from, to).Return([]*remote.Event{{Subject: "Test Event"}}, nil).Times(1)
+			},
+			assertions: func(t *testing.T, events []*remote.Event, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, events)
+				require.Len(t, events, 1)
+				require.Equal(t, "Test Event", events[0].Subject, "Expected first event's subject to be %s, but got %s", "Test Event", events[0].Subject)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setupMock()
+
+			events, err := mscalendar.ViewCalendar(tt.user, from, to)
+
+			tt.assertions(t, events, err)
+		})
+	}
+}
+
+func TestGetTodayCalendarEvents(t *testing.T) {
+	mscalendar, mockStore, _, _, _, mockClient, _ := MockSetup(t)
+
+	mscalendar.Config = &config.Config{
+		Provider: config.ProviderConfig{
+			DisplayName:    "testDisplayName",
+			CommandTrigger: "testCommandTrigger",
+		},
+	}
+
+	now := time.Now()
+	timezone := "America/Los_Angeles"
+	from, to := getTodayHoursForTimezone(now, timezone)
+
+	tests := []struct {
+		name       string
+		user       *User
+		setupMock  func()
+		assertions func(t *testing.T, events []*remote.Event, err error)
+	}{
+		{
+			name: "error expanding remote user",
+			user: &User{
+				User:             nil,
+				MattermostUser:   &model.User{Id: "testMMID"},
+				MattermostUserID: "testMMUserID",
+			},
+			setupMock: func() {
+				mockStore.EXPECT().LoadUser("testMMUserID").Return(nil, errors.New("error loading the user")).Times(1)
+			},
+			assertions: func(t *testing.T, events []*remote.Event, err error) {
+				require.Error(t, err)
+				require.EqualError(t, err, "It looks like your Mattermost account is not connected to testDisplayName. Please connect your account using `/testCommandTrigger connect`.: error loading the user")
+			},
+		},
+		{
+			name: "error getting calendar view",
+			user: &User{
+				User:             &store.User{Remote: &remote.User{ID: "testRemoteUserID"}},
+				MattermostUser:   &model.User{Id: "testMMID"},
+				MattermostUserID: "testMMUserID",
+			},
+			setupMock: func() {
+				mockClient.EXPECT().GetDefaultCalendarView("testRemoteUserID", from, to).Return(nil, fmt.Errorf("error getting calendar view")).Times(1)
+			},
+			assertions: func(t *testing.T, events []*remote.Event, err error) {
+				require.Error(t, err)
+				require.EqualError(t, err, "error getting calendar view")
+			},
+		},
+		{
+			name: "successful calendar view",
+			user: &User{
+				User:             &store.User{Remote: &remote.User{ID: "testRemoteUserID"}},
+				MattermostUser:   &model.User{Id: "testMMID"},
+				MattermostUserID: "testMMUserID",
+			},
+			setupMock: func() {
+				mockClient.EXPECT().GetDefaultCalendarView("testRemoteUserID", from, to).Return([]*remote.Event{{Subject: "Today's Test Event"}}, nil).Times(1)
+			},
+			assertions: func(t *testing.T, events []*remote.Event, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, events)
+				require.Len(t, events, 1)
+				require.Equal(t, "Today's Test Event", events[0].Subject, "Expected first event's subject to be %s, but got %s", "Today's Test Event", events[0].Subject)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setupMock()
+
+			events, err := mscalendar.getTodayCalendarEvents(tt.user, now, timezone)
+
+			tt.assertions(t, events, err)
+		})
+	}
+}
+
+func TestCreateCalendar(t *testing.T) {
+	mscalendar, mockStore, _, _, _, mockClient, _ := MockSetup(t)
+
+	mscalendar.Config = &config.Config{
+		Provider: config.ProviderConfig{
+			DisplayName:    "testDisplayName",
+			CommandTrigger: "testCommandTrigger",
+		},
+	}
+
+	tests := []struct {
+		name       string
+		user       *User
+		calendar   *remote.Calendar
+		setupMock  func()
+		assertions func(t *testing.T, createdCalendar *remote.Calendar, err error)
+	}{
+		{
+			name: "error expanding user",
+			user: &User{
+				MattermostUserID: "testMMUserID",
+			},
+			calendar: &remote.Calendar{
+				Name: "Test Calendar",
+			},
+			setupMock: func() {
+				mockStore.EXPECT().LoadUser("testMMUserID").Return(nil, errors.New("error loading the user")).Times(1)
+			},
+			assertions: func(t *testing.T, createdCalendar *remote.Calendar, err error) {
+				require.Error(t, err)
+				require.EqualError(t, err, "It looks like your Mattermost account is not connected to testDisplayName. Please connect your account using `/testCommandTrigger connect`.: error loading the user")
+			},
+		},
+		{
+			name: "error creating calendar",
+			user: &User{
+				User:             &store.User{Remote: &remote.User{ID: "testRemoteUserID"}},
+				MattermostUser:   &model.User{Id: "testMMUserID"},
+				MattermostUserID: "testMMUserID",
+			},
+			calendar: &remote.Calendar{
+				Name: "Test Calendar",
+			},
+			setupMock: func() {
+				mockClient.EXPECT().CreateCalendar("testRemoteUserID", &remote.Calendar{Name: "Test Calendar"}).Return(nil, fmt.Errorf("error creating calendar")).Times(1)
+			},
+			assertions: func(t *testing.T, createdCalendar *remote.Calendar, err error) {
+				require.Error(t, err)
+				require.EqualError(t, err, "error creating calendar")
+			},
+		},
+		{
+			name: "successful calendar creation",
+			user: &User{
+				User:             &store.User{Remote: &remote.User{ID: "testRemoteUserID"}},
+				MattermostUser:   &model.User{Id: "testMMUserID"},
+				MattermostUserID: "testMMUserID",
+			},
+			calendar: &remote.Calendar{
+				Name: "Test Calendar",
+			},
+			setupMock: func() {
+				mockClient.EXPECT().CreateCalendar("testRemoteUserID", &remote.Calendar{Name: "Test Calendar"}).Return(&remote.Calendar{Name: "Created Test Calendar"}, nil).Times(1)
+			},
+			assertions: func(t *testing.T, createdCalendar *remote.Calendar, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, createdCalendar)
+				require.Equal(t, "Created Test Calendar", createdCalendar.Name, "Expected calendar name to be %s, but got %s", "Created Test Calendar", createdCalendar.Name)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setupMock()
+			createdCalendar, err := mscalendar.CreateCalendar(tt.user, tt.calendar)
+			tt.assertions(t, createdCalendar, err)
+		})
+	}
+}
+
+func TestCreateEvent(t *testing.T) {
+	mscalendar, mockStore, mockPoster, _, mockPluginAPI, mockClient, mockLogger := MockSetup(t)
+
+	tests := []struct {
+		name              string
+		user              *User
+		event             *remote.Event
+		mattermostUserIDs []string
+		setupMock         func()
+		assertions        func(t *testing.T, createdEvent *remote.Event, err error)
+		expectedEvent     *remote.Event
+	}{
+		{
+			name: "error expanding user",
+			user: &User{
+				MattermostUserID: "testMMUserID",
+			},
+			event:             &remote.Event{Subject: "Test Event"},
+			mattermostUserIDs: []string{"testMMUserID1"},
+			setupMock: func() {
+				mockStore.EXPECT().LoadUser("testMMUserID").Return(nil, errors.New("error loading the user")).Times(1)
+			},
+			assertions: func(t *testing.T, createdEvent *remote.Event, err error) {
+				require.Error(t, err)
+				require.EqualError(t, err, "It looks like your Mattermost account is not connected to testDisplayName. Please connect your account using `/testCommandTrigger connect`.: error loading the user")
+			},
+		},
+		{
+			name: "error creating direct message",
+			user: &User{
+				User:             &store.User{Remote: &remote.User{ID: "testRemoteUserID"}},
+				MattermostUserID: "testMMUserID",
+			},
+			event:             &remote.Event{Subject: "Test Event"},
+			mattermostUserIDs: []string{"testMMUserID1"},
+			setupMock: func() {
+				mockStore.EXPECT().LoadUser("testMMUserID1").Return(nil, errors.New("not found")).Times(1)
+				mockPluginAPI.EXPECT().GetMattermostUser("testMMUserID")
+				mockPoster.EXPECT().DM("testMMUserID1", gomock.Any(), "testDisplayName", "testDisplayName", "testCommandTrigger").Return("", fmt.Errorf("error creating DM")).Times(1)
+				mockLogger.EXPECT().Warnf(gomock.Any(), gomock.Any())
+				mockClient.EXPECT().CreateEvent("testRemoteUserID", gomock.Any()).Return(&remote.Event{}, nil).Times(1)
+			},
+			assertions: func(t *testing.T, createdEvent *remote.Event, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, createdEvent)
+				require.Equal(t, &remote.Event{}, createdEvent)
+			},
+		},
+		{
+			name: "error creating event",
+			user: &User{
+				User:             &store.User{Remote: &remote.User{ID: "testRemoteUserID"}},
+				MattermostUserID: "testMMUserID",
+			},
+			event:             &remote.Event{Subject: "Test Event"},
+			mattermostUserIDs: []string{"testMMUserID1"},
+			setupMock: func() {
+				mockStore.EXPECT().LoadUser("testMMUserID1").Return(nil, errors.New("not found")).Times(1)
+				mockPluginAPI.EXPECT().GetMattermostUser("testMMUserID")
+				mockPoster.EXPECT().DM("testMMUserID1", gomock.Any(), "testDisplayName", "testDisplayName", "testCommandTrigger").Return("", fmt.Errorf("error creating DM")).Times(1).Return("", nil)
+				mockClient.EXPECT().CreateEvent("testRemoteUserID", &remote.Event{Subject: "Test Event"}).Return(nil, fmt.Errorf("error creating event")).Times(1)
+			},
+			assertions: func(t *testing.T, createdEvent *remote.Event, err error) {
+				require.Error(t, err)
+				require.EqualError(t, err, "error creating event")
+			},
+		},
+		{
+			name: "successful event creation",
+			user: &User{
+				User:             &store.User{Remote: &remote.User{ID: "testRemoteUserID"}},
+				MattermostUserID: "testMMUserID",
+			},
+			event: &remote.Event{
+				Subject:   "Test Event",
+				Location:  &remote.Location{DisplayName: "Test Location"},
+				Start:     &remote.DateTime{DateTime: "2024-10-01T09:00:00", TimeZone: "UTC"},
+				End:       &remote.DateTime{DateTime: "2024-10-01T10:00:00", TimeZone: "UTC"},
+				Attendees: []*remote.Attendee{{EmailAddress: &remote.EmailAddress{Address: "attendee1@example.com"}}},
+			},
+			mattermostUserIDs: []string{"testMMUserID1"},
+			setupMock: func() {
+				mockStore.EXPECT().LoadUser("testMMUserID1").Return(nil, errors.New("not found")).Times(1)
+				mockPluginAPI.EXPECT().GetMattermostUser("testMMUserID")
+				mockPoster.EXPECT().DM("testMMUserID1", gomock.Any(), "testDisplayName", "testDisplayName", "testCommandTrigger").Return("", fmt.Errorf("error creating DM")).Times(1).Return("", nil)
+				mockClient.EXPECT().CreateEvent("testRemoteUserID", &remote.Event{
+					Subject:   "Test Event",
+					Location:  &remote.Location{DisplayName: "Test Location"},
+					Start:     &remote.DateTime{DateTime: "2024-10-01T09:00:00", TimeZone: "UTC"},
+					End:       &remote.DateTime{DateTime: "2024-10-01T10:00:00", TimeZone: "UTC"},
+					Attendees: []*remote.Attendee{{EmailAddress: &remote.EmailAddress{Address: "attendee1@example.com"}}},
+				}).Return(&remote.Event{Subject: "Created Test Event", ID: "123"}, nil).Times(1)
+			},
+			assertions: func(t *testing.T, createdEvent *remote.Event, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, createdEvent)
+				require.Equal(t, &remote.Event{Subject: "Created Test Event", ID: "123"}, createdEvent)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setupMock()
+			createdEvent, err := mscalendar.CreateEvent(tt.user, tt.event, tt.mattermostUserIDs)
+			tt.assertions(t, createdEvent, err)
+		})
+	}
+}
+
+func TestDeleteCalendar(t *testing.T) {
+	mscalendar, mockStore, _, _, mockPluginAPI, mockClient, _ := MockSetup(t)
+
+	mscalendar.Config = &config.Config{
+		Provider: config.ProviderConfig{
+			DisplayName:    "testDisplayName",
+			CommandTrigger: "testCommandTrigger",
+		},
+	}
+
+	user := &User{
+		MattermostUserID: "testMMUserID",
+	}
+
+	tests := []struct {
+		name       string
+		calendarID string
+		setupMock  func()
+		assertions func(t *testing.T, err error)
+	}{
+		{
+			name:       "error filtering with client",
+			calendarID: "testCalendarID",
+			setupMock: func() {
+				user.User = nil
+				mockStore.EXPECT().LoadUser("testMMUserID").Return(nil, errors.New("error loading the user")).Times(1)
+			},
+			assertions: func(t *testing.T, err error) {
+				require.Error(t, err)
+				require.EqualError(t, err, "It looks like your Mattermost account is not connected to testDisplayName. Please connect your account using `/testCommandTrigger connect`.: error loading the user")
+			},
+		},
+		{
+			name:       "error deleting calendar",
+			calendarID: "testCalendarID",
+			setupMock: func() {
+				user.User = &store.User{Remote: &remote.User{ID: "testRemoteUserID"}}
+				mockPluginAPI.EXPECT().GetMattermostUser("testMMUserID")
+				mockClient.EXPECT().DeleteCalendar(user.User.Remote.ID, "testCalendarID").Return(errors.New("deletion error")).Times(1)
+			},
+			assertions: func(t *testing.T, err error) {
+				require.Error(t, err)
+				require.EqualError(t, err, "deletion error")
+			},
+		},
+		{
+			name:       "successful calendar deletion",
+			calendarID: "testCalendarID",
+			setupMock: func() {
+				mockPluginAPI.EXPECT().GetMattermostUser("testMMUserID")
+				user.User = &store.User{Remote: &remote.User{ID: "testRemoteUserID"}}
+				mockClient.EXPECT().DeleteCalendar(user.User.Remote.ID, "testCalendarID").Return(nil).Times(1)
+			},
+			assertions: func(t *testing.T, err error) {
+				require.NoError(t, err)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setupMock()
+
+			err := mscalendar.DeleteCalendar(user, tt.calendarID)
+
+			tt.assertions(t, err)
+		})
+	}
+}
+
+func TestFindMeetingTimes(t *testing.T) {
+	mscalendar, mockStore, _, _, mockPluginAPI, mockClient, _ := MockSetup(t)
+
+	mscalendar.Config = &config.Config{
+		Provider: config.ProviderConfig{
+			DisplayName:    "testDisplayName",
+			CommandTrigger: "testCommandTrigger",
+		},
+	}
+
+	user := &User{
+		MattermostUserID: "testMMUserID",
+	}
+
+	meetingParams := &remote.FindMeetingTimesParameters{}
+
+	tests := []struct {
+		name       string
+		setupMock  func()
+		assertions func(t *testing.T, err error, results *remote.MeetingTimeSuggestionResults)
+	}{
+		{
+			name: "error filtering with client",
+			setupMock: func() {
+				mockStore.EXPECT().LoadUser("testMMUserID").Return(nil, errors.New("error loading the user")).Times(1)
+			},
+			assertions: func(t *testing.T, err error, results *remote.MeetingTimeSuggestionResults) {
+				require.Error(t, err)
+				require.EqualError(t, err, "It looks like your Mattermost account is not connected to testDisplayName. Please connect your account using `/testCommandTrigger connect`.: error loading the user")
+				require.Nil(t, results)
+			},
+		},
+		{
+			name: "error finding meeting times",
+			setupMock: func() {
+				user.User = &store.User{Remote: &remote.User{ID: "testRemoteUserID"}}
+				mockPluginAPI.EXPECT().GetMattermostUser("testMMUserID")
+				mockClient.EXPECT().FindMeetingTimes(user.User.Remote.ID, meetingParams).Return(nil, errors.New("finding times error")).Times(1)
+			},
+			assertions: func(t *testing.T, err error, results *remote.MeetingTimeSuggestionResults) {
+				require.Error(t, err)
+				require.EqualError(t, err, "finding times error")
+				require.Nil(t, results)
+			},
+		},
+		{
+			name: "successful meeting time retrieval",
+			setupMock: func() {
+				user.User = &store.User{Remote: &remote.User{ID: "testRemoteUserID"}}
+				mockPluginAPI.EXPECT().GetMattermostUser("testMMUserID")
+				mockClient.EXPECT().FindMeetingTimes(user.User.Remote.ID, meetingParams).Return(&remote.MeetingTimeSuggestionResults{}, nil).Times(1)
+			},
+			assertions: func(t *testing.T, err error, results *remote.MeetingTimeSuggestionResults) {
+				require.NoError(t, err)
+				require.NotNil(t, results)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setupMock()
+
+			results, err := mscalendar.FindMeetingTimes(user, meetingParams)
+
+			tt.assertions(t, err, results)
+		})
+	}
+}
+
+func TestGetCalendars(t *testing.T) {
+	mscalendar, mockStore, _, _, mockPluginAPI, mockClient, _ := MockSetup(t)
+
+	user := &User{
+		MattermostUserID: "testMMUserID",
+	}
+
+	tests := []struct {
+		name       string
+		setupMock  func()
+		assertions func(t *testing.T, err error, calendars []*remote.Calendar)
+	}{
+		{
+			name: "error filtering with client",
+			setupMock: func() {
+				mockStore.EXPECT().LoadUser("testMMUserID").Return(nil, errors.New("error loading the user")).Times(1)
+			},
+			assertions: func(t *testing.T, err error, calendars []*remote.Calendar) {
+				require.Error(t, err)
+				require.EqualError(t, err, "It looks like your Mattermost account is not connected to testDisplayName. Please connect your account using `/testCommandTrigger connect`.: error loading the user")
+				require.Nil(t, calendars)
+			},
+		},
+		{
+			name: "error getting calendars",
+			setupMock: func() {
+				user.User = &store.User{Remote: &remote.User{ID: "testRemoteUserID"}}
+				mockPluginAPI.EXPECT().GetMattermostUser("testMMUserID")
+				mockClient.EXPECT().GetCalendars(user.User.Remote.ID).Return(nil, errors.New("getting calendars error")).Times(1)
+			},
+			assertions: func(t *testing.T, err error, calendars []*remote.Calendar) {
+				require.Error(t, err)
+				require.EqualError(t, err, "getting calendars error")
+				require.Nil(t, calendars)
+			},
+		},
+		{
+			name: "successful calendars retrieval",
+			setupMock: func() {
+				user.User = &store.User{Remote: &remote.User{ID: "testRemoteUserID"}}
+				mockPluginAPI.EXPECT().GetMattermostUser("testMMUserID")
+				mockClient.EXPECT().GetCalendars(user.User.Remote.ID).Return([]*remote.Calendar{{ID: "calendar1"}}, nil).Times(1)
+			},
+			assertions: func(t *testing.T, err error, calendars []*remote.Calendar) {
+				require.NoError(t, err)
+				require.Equal(t, []*remote.Calendar{{ID: "calendar1"}}, calendars)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setupMock()
+
+			calendars, err := mscalendar.GetCalendars(user)
+
+			tt.assertions(t, err, calendars)
+		})
+	}
+}
+
+// revive:disable:unexported-return
+func MockSetup(t *testing.T) (*mscalendar, *mock_store.MockStore, *mock_bot.MockPoster, *mock_remote.MockRemote, *mock_plugin_api.MockPluginAPI, *mock_remote.MockClient, *mock_bot.MockLogger) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := mock_store.NewMockStore(ctrl)
+	mockPoster := mock_bot.NewMockPoster(ctrl)
+	mockRemote := mock_remote.NewMockRemote(ctrl)
+	mockPluginAPI := mock_plugin_api.NewMockPluginAPI(ctrl)
+	mockClient := mock_remote.NewMockClient(ctrl)
+	mockLogger := mock_bot.NewMockLogger(ctrl)
+
+	env := Env{
+		Dependencies: &Dependencies{
+			Store:     mockStore,
+			Poster:    mockPoster,
+			Remote:    mockRemote,
+			PluginAPI: mockPluginAPI,
+			Logger:    mockLogger,
+		},
+	}
+
+	mscalendar := &mscalendar{
+		Env:    env,
+		client: mockClient,
+	}
+
+	mscalendar.Config = &config.Config{
+		Provider: config.ProviderConfig{
+			DisplayName:    "testDisplayName",
+			CommandTrigger: "testCommandTrigger",
+		},
+	}
+
+	return mscalendar, mockStore, mockPoster, mockRemote, mockPluginAPI, mockClient, mockLogger
+}

--- a/calendar/engine/calendar_test.go
+++ b/calendar/engine/calendar_test.go
@@ -23,13 +23,6 @@ import (
 func TestViewCalendar(t *testing.T) {
 	mscalendar, mockStore, _, _, _, mockClient, _ := MockSetup(t)
 
-	mscalendar.Config = &config.Config{
-		Provider: config.ProviderConfig{
-			DisplayName:    "testDisplayName",
-			CommandTrigger: "testCommandTrigger",
-		},
-	}
-
 	now := time.Now()
 	from := now.Add(-time.Hour)
 	to := now.Add(time.Hour)
@@ -48,11 +41,11 @@ func TestViewCalendar(t *testing.T) {
 				MattermostUserID: "testMMUserID",
 			},
 			setupMock: func() {
-				mockStore.EXPECT().LoadUser(gomock.Any()).Return(nil, errors.New("error loading the user")).Times(1)
+				mockStore.EXPECT().LoadUser("testMMUserID").Return(nil, errors.New("error loading the user")).Times(1)
 			},
 			assertions: func(t *testing.T, events []*remote.Event, err error) {
 				require.Error(t, err)
-				require.EqualError(t, err, "It looks like your Mattermost account is not connected to testDisplayName. Please connect your account using `/testCommandTrigger connect`.: error loading the user")
+				require.ErrorContains(t, err, "error loading the user")
 			},
 		},
 		{
@@ -88,7 +81,6 @@ func TestViewCalendar(t *testing.T) {
 			},
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.setupMock()
@@ -102,13 +94,6 @@ func TestViewCalendar(t *testing.T) {
 
 func TestGetTodayCalendarEvents(t *testing.T) {
 	mscalendar, mockStore, _, _, _, mockClient, _ := MockSetup(t)
-
-	mscalendar.Config = &config.Config{
-		Provider: config.ProviderConfig{
-			DisplayName:    "testDisplayName",
-			CommandTrigger: "testCommandTrigger",
-		},
-	}
 
 	now := time.Now()
 	timezone := "America/Los_Angeles"
@@ -132,7 +117,7 @@ func TestGetTodayCalendarEvents(t *testing.T) {
 			},
 			assertions: func(t *testing.T, events []*remote.Event, err error) {
 				require.Error(t, err)
-				require.EqualError(t, err, "It looks like your Mattermost account is not connected to testDisplayName. Please connect your account using `/testCommandTrigger connect`.: error loading the user")
+				require.ErrorContains(t, err, "error loading the user")
 			},
 		},
 		{
@@ -168,7 +153,6 @@ func TestGetTodayCalendarEvents(t *testing.T) {
 			},
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.setupMock()
@@ -182,13 +166,6 @@ func TestGetTodayCalendarEvents(t *testing.T) {
 
 func TestCreateCalendar(t *testing.T) {
 	mscalendar, mockStore, _, _, _, mockClient, _ := MockSetup(t)
-
-	mscalendar.Config = &config.Config{
-		Provider: config.ProviderConfig{
-			DisplayName:    "testDisplayName",
-			CommandTrigger: "testCommandTrigger",
-		},
-	}
 
 	tests := []struct {
 		name       string
@@ -210,7 +187,7 @@ func TestCreateCalendar(t *testing.T) {
 			},
 			assertions: func(t *testing.T, createdCalendar *remote.Calendar, err error) {
 				require.Error(t, err)
-				require.EqualError(t, err, "It looks like your Mattermost account is not connected to testDisplayName. Please connect your account using `/testCommandTrigger connect`.: error loading the user")
+				require.ErrorContains(t, err, "error loading the user")
 			},
 		},
 		{
@@ -251,7 +228,6 @@ func TestCreateCalendar(t *testing.T) {
 			},
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.setupMock()
@@ -268,7 +244,6 @@ func TestCreateEvent(t *testing.T) {
 		name              string
 		user              *User
 		event             *remote.Event
-		mattermostUserIDs []string
 		setupMock         func()
 		assertions        func(t *testing.T, createdEvent *remote.Event, err error)
 		expectedEvent     *remote.Event
@@ -279,13 +254,12 @@ func TestCreateEvent(t *testing.T) {
 				MattermostUserID: "testMMUserID",
 			},
 			event:             &remote.Event{Subject: "Test Event"},
-			mattermostUserIDs: []string{"testMMUserID1"},
 			setupMock: func() {
 				mockStore.EXPECT().LoadUser("testMMUserID").Return(nil, errors.New("error loading the user")).Times(1)
 			},
 			assertions: func(t *testing.T, createdEvent *remote.Event, err error) {
 				require.Error(t, err)
-				require.EqualError(t, err, "It looks like your Mattermost account is not connected to testDisplayName. Please connect your account using `/testCommandTrigger connect`.: error loading the user")
+				require.ErrorContains(t, err, "error loading the user")
 			},
 		},
 		{
@@ -295,12 +269,11 @@ func TestCreateEvent(t *testing.T) {
 				MattermostUserID: "testMMUserID",
 			},
 			event:             &remote.Event{Subject: "Test Event"},
-			mattermostUserIDs: []string{"testMMUserID1"},
 			setupMock: func() {
-				mockStore.EXPECT().LoadUser("testMMUserID1").Return(nil, errors.New("not found")).Times(1)
+				mockStore.EXPECT().LoadUser("testMMUserID").Return(nil, errors.New("not found")).Times(1)
 				mockPluginAPI.EXPECT().GetMattermostUser("testMMUserID")
-				mockPoster.EXPECT().DM("testMMUserID1", gomock.Any(), "testDisplayName", "testDisplayName", "testCommandTrigger").Return("", fmt.Errorf("error creating DM")).Times(1)
-				mockLogger.EXPECT().Warnf(gomock.Any(), gomock.Any())
+				mockPoster.EXPECT().DM("testMMUserID", gomock.AssignableToTypeOf(""), "testDisplayName", "testDisplayName", "testCommandTrigger").Return("", fmt.Errorf("error creating DM")).Times(1)
+				mockLogger.EXPECT().Warnf("CreateEvent error creating DM. err=%v", gomock.Any())
 				mockClient.EXPECT().CreateEvent("testRemoteUserID", gomock.Any()).Return(&remote.Event{}, nil).Times(1)
 			},
 			assertions: func(t *testing.T, createdEvent *remote.Event, err error) {
@@ -316,11 +289,10 @@ func TestCreateEvent(t *testing.T) {
 				MattermostUserID: "testMMUserID",
 			},
 			event:             &remote.Event{Subject: "Test Event"},
-			mattermostUserIDs: []string{"testMMUserID1"},
 			setupMock: func() {
-				mockStore.EXPECT().LoadUser("testMMUserID1").Return(nil, errors.New("not found")).Times(1)
+				mockStore.EXPECT().LoadUser("testMMUserID").Return(nil, errors.New("not found")).Times(1)
 				mockPluginAPI.EXPECT().GetMattermostUser("testMMUserID")
-				mockPoster.EXPECT().DM("testMMUserID1", gomock.Any(), "testDisplayName", "testDisplayName", "testCommandTrigger").Return("", fmt.Errorf("error creating DM")).Times(1).Return("", nil)
+				mockPoster.EXPECT().DM("testMMUserID", gomock.AssignableToTypeOf(""), "testDisplayName", "testDisplayName", "testCommandTrigger").Return("", fmt.Errorf("error creating DM")).Times(1).Return("", nil)
 				mockClient.EXPECT().CreateEvent("testRemoteUserID", &remote.Event{Subject: "Test Event"}).Return(nil, fmt.Errorf("error creating event")).Times(1)
 			},
 			assertions: func(t *testing.T, createdEvent *remote.Event, err error) {
@@ -341,11 +313,10 @@ func TestCreateEvent(t *testing.T) {
 				End:       &remote.DateTime{DateTime: "2024-10-01T10:00:00", TimeZone: "UTC"},
 				Attendees: []*remote.Attendee{{EmailAddress: &remote.EmailAddress{Address: "attendee1@example.com"}}},
 			},
-			mattermostUserIDs: []string{"testMMUserID1"},
 			setupMock: func() {
-				mockStore.EXPECT().LoadUser("testMMUserID1").Return(nil, errors.New("not found")).Times(1)
+				mockStore.EXPECT().LoadUser("testMMUserID").Return(nil, errors.New("not found")).Times(1)
 				mockPluginAPI.EXPECT().GetMattermostUser("testMMUserID")
-				mockPoster.EXPECT().DM("testMMUserID1", gomock.Any(), "testDisplayName", "testDisplayName", "testCommandTrigger").Return("", fmt.Errorf("error creating DM")).Times(1).Return("", nil)
+				mockPoster.EXPECT().DM("testMMUserID", gomock.AssignableToTypeOf(""), "testDisplayName", "testDisplayName", "testCommandTrigger").Return("", fmt.Errorf("error creating DM")).Times(1).Return("", nil)
 				mockClient.EXPECT().CreateEvent("testRemoteUserID", &remote.Event{
 					Subject:   "Test Event",
 					Location:  &remote.Location{DisplayName: "Test Location"},
@@ -361,11 +332,10 @@ func TestCreateEvent(t *testing.T) {
 			},
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.setupMock()
-			createdEvent, err := mscalendar.CreateEvent(tt.user, tt.event, tt.mattermostUserIDs)
+			createdEvent, err := mscalendar.CreateEvent(tt.user, tt.event, []string{"testMMUserID"})
 			tt.assertions(t, createdEvent, err)
 		})
 	}
@@ -373,13 +343,6 @@ func TestCreateEvent(t *testing.T) {
 
 func TestDeleteCalendar(t *testing.T) {
 	mscalendar, mockStore, _, _, mockPluginAPI, mockClient, _ := MockSetup(t)
-
-	mscalendar.Config = &config.Config{
-		Provider: config.ProviderConfig{
-			DisplayName:    "testDisplayName",
-			CommandTrigger: "testCommandTrigger",
-		},
-	}
 
 	user := &User{
 		MattermostUserID: "testMMUserID",
@@ -400,7 +363,7 @@ func TestDeleteCalendar(t *testing.T) {
 			},
 			assertions: func(t *testing.T, err error) {
 				require.Error(t, err)
-				require.EqualError(t, err, "It looks like your Mattermost account is not connected to testDisplayName. Please connect your account using `/testCommandTrigger connect`.: error loading the user")
+				require.ErrorContains(t, err, "error loading the user")
 			},
 		},
 		{
@@ -429,7 +392,6 @@ func TestDeleteCalendar(t *testing.T) {
 			},
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.setupMock()
@@ -443,13 +405,6 @@ func TestDeleteCalendar(t *testing.T) {
 
 func TestFindMeetingTimes(t *testing.T) {
 	mscalendar, mockStore, _, _, mockPluginAPI, mockClient, _ := MockSetup(t)
-
-	mscalendar.Config = &config.Config{
-		Provider: config.ProviderConfig{
-			DisplayName:    "testDisplayName",
-			CommandTrigger: "testCommandTrigger",
-		},
-	}
 
 	user := &User{
 		MattermostUserID: "testMMUserID",
@@ -469,7 +424,7 @@ func TestFindMeetingTimes(t *testing.T) {
 			},
 			assertions: func(t *testing.T, err error, results *remote.MeetingTimeSuggestionResults) {
 				require.Error(t, err)
-				require.EqualError(t, err, "It looks like your Mattermost account is not connected to testDisplayName. Please connect your account using `/testCommandTrigger connect`.: error loading the user")
+				require.ErrorContains(t, err, "error loading the user")
 				require.Nil(t, results)
 			},
 		},
@@ -499,7 +454,6 @@ func TestFindMeetingTimes(t *testing.T) {
 			},
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.setupMock()
@@ -530,7 +484,7 @@ func TestGetCalendars(t *testing.T) {
 			},
 			assertions: func(t *testing.T, err error, calendars []*remote.Calendar) {
 				require.Error(t, err)
-				require.EqualError(t, err, "It looks like your Mattermost account is not connected to testDisplayName. Please connect your account using `/testCommandTrigger connect`.: error loading the user")
+				require.ErrorContains(t, err, "error loading the user")
 				require.Nil(t, calendars)
 			},
 		},
@@ -560,7 +514,6 @@ func TestGetCalendars(t *testing.T) {
 			},
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.setupMock()

--- a/calendar/engine/calendar_test.go
+++ b/calendar/engine/calendar_test.go
@@ -31,7 +31,7 @@ func TestViewCalendar(t *testing.T) {
 			name: "error filtering with client",
 			user: GetMockUser(nil, model.NewString(MockMMModelUserID), MockMMUserID),
 			setupMock: func() {
-				mockStore.EXPECT().LoadUser("testMMUserID").Return(nil, errors.New("error loading the user")).Times(1)
+				mockStore.EXPECT().LoadUser(MockMMUserID).Return(nil, errors.New("error loading the user")).Times(1)
 			},
 			assertions: func(t *testing.T, events []*remote.Event, err error) {
 				require.Error(t, err)
@@ -42,7 +42,7 @@ func TestViewCalendar(t *testing.T) {
 			name: "error getting calendar view",
 			user: GetMockUser(model.NewString(MockRemoteUserID), model.NewString(MockMMModelUserID), MockMMUserID),
 			setupMock: func() {
-				mockClient.EXPECT().GetDefaultCalendarView("testRemoteUserID", from, to).Return(nil, fmt.Errorf("error getting calendar view")).Times(1)
+				mockClient.EXPECT().GetDefaultCalendarView(MockRemoteUserID, from, to).Return(nil, fmt.Errorf("error getting calendar view")).Times(1)
 			},
 			assertions: func(t *testing.T, events []*remote.Event, err error) {
 				require.Error(t, err)
@@ -53,7 +53,7 @@ func TestViewCalendar(t *testing.T) {
 			name: "successful calendar view",
 			user: GetMockUser(model.NewString(MockRemoteUserID), model.NewString(MockMMModelUserID), MockMMUserID),
 			setupMock: func() {
-				mockClient.EXPECT().GetDefaultCalendarView("testRemoteUserID", from, to).Return([]*remote.Event{{Subject: "Test Event"}}, nil).Times(1)
+				mockClient.EXPECT().GetDefaultCalendarView(MockRemoteUserID, from, to).Return([]*remote.Event{{Subject: "Test Event"}}, nil).Times(1)
 			},
 			assertions: func(t *testing.T, events []*remote.Event, err error) {
 				require.NoError(t, err)
@@ -90,7 +90,7 @@ func TestGetTodayCalendarEvents(t *testing.T) {
 			name: "error expanding remote user",
 			user: GetMockUser(nil, model.NewString(MockMMModelUserID), MockMMUserID),
 			setupMock: func() {
-				mockStore.EXPECT().LoadUser("testMMUserID").Return(nil, errors.New("error loading the user")).Times(1)
+				mockStore.EXPECT().LoadUser(MockMMUserID).Return(nil, errors.New("error loading the user")).Times(1)
 			},
 			assertions: func(t *testing.T, events []*remote.Event, err error) {
 				require.Error(t, err)
@@ -101,7 +101,7 @@ func TestGetTodayCalendarEvents(t *testing.T) {
 			name: "error getting calendar view",
 			user: GetMockUser(model.NewString(MockRemoteUserID), model.NewString(MockMMModelUserID), MockMMUserID),
 			setupMock: func() {
-				mockClient.EXPECT().GetDefaultCalendarView("testRemoteUserID", from, to).Return(nil, fmt.Errorf("error getting calendar view")).Times(1)
+				mockClient.EXPECT().GetDefaultCalendarView(MockRemoteUserID, from, to).Return(nil, fmt.Errorf("error getting calendar view")).Times(1)
 			},
 			assertions: func(t *testing.T, events []*remote.Event, err error) {
 				require.Error(t, err)
@@ -112,7 +112,7 @@ func TestGetTodayCalendarEvents(t *testing.T) {
 			name: "successful calendar view",
 			user: GetMockUser(model.NewString(MockRemoteUserID), model.NewString(MockMMModelUserID), MockMMUserID),
 			setupMock: func() {
-				mockClient.EXPECT().GetDefaultCalendarView("testRemoteUserID", from, to).Return([]*remote.Event{{Subject: "Today's Test Event"}}, nil).Times(1)
+				mockClient.EXPECT().GetDefaultCalendarView(MockRemoteUserID, from, to).Return([]*remote.Event{{Subject: "Today's Test Event"}}, nil).Times(1)
 			},
 			assertions: func(t *testing.T, events []*remote.Event, err error) {
 				require.NoError(t, err)
@@ -148,7 +148,7 @@ func TestCreateCalendar(t *testing.T) {
 			user:     GetMockUser(nil, nil, MockMMUserID),
 			calendar: GetMockCalendar(MockCalendarName),
 			setupMock: func() {
-				mockStore.EXPECT().LoadUser("testMMUserID").Return(nil, errors.New("error loading the user")).Times(1)
+				mockStore.EXPECT().LoadUser(MockMMUserID).Return(nil, errors.New("error loading the user")).Times(1)
 			},
 			assertions: func(t *testing.T, createdCalendar *remote.Calendar, err error) {
 				require.Error(t, err)
@@ -160,7 +160,7 @@ func TestCreateCalendar(t *testing.T) {
 			user:     GetMockUser(model.NewString(MockRemoteUserID), model.NewString(MockMMModelUserID), MockMMUserID),
 			calendar: GetMockCalendar(MockCalendarName),
 			setupMock: func() {
-				mockClient.EXPECT().CreateCalendar("testRemoteUserID", &remote.Calendar{Name: "Test Calendar"}).Return(nil, fmt.Errorf("error creating calendar")).Times(1)
+				mockClient.EXPECT().CreateCalendar(MockRemoteUserID, &remote.Calendar{Name: MockCalendarName}).Return(nil, fmt.Errorf("error creating calendar")).Times(1)
 			},
 			assertions: func(t *testing.T, createdCalendar *remote.Calendar, err error) {
 				require.Error(t, err)
@@ -172,7 +172,7 @@ func TestCreateCalendar(t *testing.T) {
 			user:     GetMockUser(model.NewString(MockRemoteUserID), model.NewString(MockMMModelUserID), MockMMUserID),
 			calendar: GetMockCalendar(MockCalendarName),
 			setupMock: func() {
-				mockClient.EXPECT().CreateCalendar("testRemoteUserID", &remote.Calendar{Name: "Test Calendar"}).Return(&remote.Calendar{Name: "Created Test Calendar"}, nil).Times(1)
+				mockClient.EXPECT().CreateCalendar(MockRemoteUserID, &remote.Calendar{Name: MockCalendarName}).Return(&remote.Calendar{Name: "Created Test Calendar"}, nil).Times(1)
 			},
 			assertions: func(t *testing.T, createdCalendar *remote.Calendar, err error) {
 				require.NoError(t, err)
@@ -206,7 +206,7 @@ func TestCreateEvent(t *testing.T) {
 			user:  GetMockUser(nil, nil, MockMMUserID),
 			event: GetMockEvent(MockEventName, nil, nil, nil, nil),
 			setupMock: func() {
-				mockStore.EXPECT().LoadUser("testMMUserID").Return(nil, errors.New("error loading the user")).Times(1)
+				mockStore.EXPECT().LoadUser(MockMMUserID).Return(nil, errors.New("error loading the user")).Times(1)
 			},
 			assertions: func(t *testing.T, createdEvent *remote.Event, err error) {
 				require.Error(t, err)
@@ -218,11 +218,11 @@ func TestCreateEvent(t *testing.T) {
 			user:  GetMockUser(model.NewString(MockRemoteUserID), nil, MockMMUserID),
 			event: GetMockEvent(MockEventName, nil, nil, nil, nil),
 			setupMock: func() {
-				mockStore.EXPECT().LoadUser("testMMUserID").Return(nil, errors.New("not found")).Times(1)
-				mockPluginAPI.EXPECT().GetMattermostUser("testMMUserID")
-				mockPoster.EXPECT().DM("testMMUserID", gomock.AssignableToTypeOf(""), "testDisplayName", "testDisplayName", "testCommandTrigger").Return("", fmt.Errorf("error creating DM")).Times(1)
+				mockStore.EXPECT().LoadUser(MockMMUserID).Return(nil, errors.New("not found")).Times(1)
+				mockPluginAPI.EXPECT().GetMattermostUser(MockMMUserID)
+				mockPoster.EXPECT().DM(MockMMUserID, gomock.AssignableToTypeOf(""), "testDisplayName", "testDisplayName", "testCommandTrigger").Return("", fmt.Errorf("error creating DM")).Times(1)
 				mockLogger.EXPECT().Warnf("CreateEvent error creating DM. err=%v", gomock.Any())
-				mockClient.EXPECT().CreateEvent("testRemoteUserID", gomock.Any()).Return(&remote.Event{}, nil).Times(1)
+				mockClient.EXPECT().CreateEvent(MockRemoteUserID, gomock.Any()).Return(&remote.Event{}, nil).Times(1)
 			},
 			assertions: func(t *testing.T, createdEvent *remote.Event, err error) {
 				require.NoError(t, err)
@@ -235,10 +235,10 @@ func TestCreateEvent(t *testing.T) {
 			user:  GetMockUser(model.NewString(MockRemoteUserID), nil, MockMMUserID),
 			event: GetMockEvent(MockEventName, nil, nil, nil, nil),
 			setupMock: func() {
-				mockStore.EXPECT().LoadUser("testMMUserID").Return(nil, errors.New("not found")).Times(1)
-				mockPluginAPI.EXPECT().GetMattermostUser("testMMUserID")
-				mockPoster.EXPECT().DM("testMMUserID", gomock.AssignableToTypeOf(""), "testDisplayName", "testDisplayName", "testCommandTrigger").Return("", fmt.Errorf("error creating DM")).Times(1).Return("", nil)
-				mockClient.EXPECT().CreateEvent("testRemoteUserID", &remote.Event{Subject: "Test Event"}).Return(nil, fmt.Errorf("error creating event")).Times(1)
+				mockStore.EXPECT().LoadUser(MockMMUserID).Return(nil, errors.New("not found")).Times(1)
+				mockPluginAPI.EXPECT().GetMattermostUser(MockMMUserID)
+				mockPoster.EXPECT().DM(MockMMUserID, gomock.AssignableToTypeOf(""), "testDisplayName", "testDisplayName", "testCommandTrigger").Return("", fmt.Errorf("error creating DM")).Times(1).Return("", nil)
+				mockClient.EXPECT().CreateEvent(MockRemoteUserID, &remote.Event{Subject: "Test Event"}).Return(nil, fmt.Errorf("error creating event")).Times(1)
 			},
 			assertions: func(t *testing.T, createdEvent *remote.Event, err error) {
 				require.Error(t, err)
@@ -256,10 +256,10 @@ func TestCreateEvent(t *testing.T) {
 				[]*remote.Attendee{{EmailAddress: &remote.EmailAddress{Address: "attendee1@example.com"}}},
 			),
 			setupMock: func() {
-				mockStore.EXPECT().LoadUser("testMMUserID").Return(nil, errors.New("not found")).Times(1)
-				mockPluginAPI.EXPECT().GetMattermostUser("testMMUserID")
-				mockPoster.EXPECT().DM("testMMUserID", gomock.AssignableToTypeOf(""), "testDisplayName", "testDisplayName", "testCommandTrigger").Return("", fmt.Errorf("error creating DM")).Times(1).Return("", nil)
-				mockClient.EXPECT().CreateEvent("testRemoteUserID", &remote.Event{
+				mockStore.EXPECT().LoadUser(MockMMUserID).Return(nil, errors.New("not found")).Times(1)
+				mockPluginAPI.EXPECT().GetMattermostUser(MockMMUserID)
+				mockPoster.EXPECT().DM(MockMMUserID, gomock.AssignableToTypeOf(""), "testDisplayName", "testDisplayName", "testCommandTrigger").Return("", fmt.Errorf("error creating DM")).Times(1).Return("", nil)
+				mockClient.EXPECT().CreateEvent(MockRemoteUserID, &remote.Event{
 					Subject:   "Test Event",
 					Location:  &remote.Location{DisplayName: "Test Location"},
 					Start:     &remote.DateTime{DateTime: "2024-10-01T09:00:00", TimeZone: "UTC"},
@@ -277,7 +277,7 @@ func TestCreateEvent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.setupMock()
-			createdEvent, err := mscalendar.CreateEvent(tt.user, tt.event, []string{"testMMUserID"})
+			createdEvent, err := mscalendar.CreateEvent(tt.user, tt.event, []string{MockMMUserID})
 			tt.assertions(t, createdEvent, err)
 		})
 	}
@@ -295,7 +295,7 @@ func TestDeleteCalendar(t *testing.T) {
 		{
 			name: "error filtering with client",
 			setupMock: func() {
-				mockStore.EXPECT().LoadUser("testMMUserID").Return(nil, errors.New("error loading the user")).Times(1)
+				mockStore.EXPECT().LoadUser(MockMMUserID).Return(nil, errors.New("error loading the user")).Times(1)
 			},
 			assertions: func(t *testing.T, err error) {
 				require.Error(t, err)
@@ -305,9 +305,9 @@ func TestDeleteCalendar(t *testing.T) {
 		{
 			name: "error deleting calendar",
 			setupMock: func() {
-				user.User = &store.User{Remote: &remote.User{ID: "testRemoteUserID"}}
-				mockPluginAPI.EXPECT().GetMattermostUser("testMMUserID")
-				mockClient.EXPECT().DeleteCalendar(user.User.Remote.ID, "testCalendarID").Return(errors.New("deletion error")).Times(1)
+				user.User = &store.User{Remote: &remote.User{ID: MockRemoteUserID}}
+				mockPluginAPI.EXPECT().GetMattermostUser(MockMMUserID)
+				mockClient.EXPECT().DeleteCalendar(user.User.Remote.ID, MockCalendarID).Return(errors.New("deletion error")).Times(1)
 			},
 			assertions: func(t *testing.T, err error) {
 				require.Error(t, err)
@@ -317,8 +317,8 @@ func TestDeleteCalendar(t *testing.T) {
 		{
 			name: "successful calendar deletion",
 			setupMock: func() {
-				mockPluginAPI.EXPECT().GetMattermostUser("testMMUserID")
-				mockClient.EXPECT().DeleteCalendar(user.User.Remote.ID, "testCalendarID").Return(nil).Times(1)
+				mockPluginAPI.EXPECT().GetMattermostUser(MockMMUserID)
+				mockClient.EXPECT().DeleteCalendar(user.User.Remote.ID, MockCalendarID).Return(nil).Times(1)
 			},
 			assertions: func(t *testing.T, err error) {
 				require.NoError(t, err)
@@ -350,7 +350,7 @@ func TestFindMeetingTimes(t *testing.T) {
 		{
 			name: "error filtering with client",
 			setupMock: func() {
-				mockStore.EXPECT().LoadUser("testMMUserID").Return(nil, errors.New("error loading the user")).Times(1)
+				mockStore.EXPECT().LoadUser(MockMMUserID).Return(nil, errors.New("error loading the user")).Times(1)
 			},
 			assertions: func(t *testing.T, err error, results *remote.MeetingTimeSuggestionResults) {
 				require.Error(t, err)
@@ -361,8 +361,8 @@ func TestFindMeetingTimes(t *testing.T) {
 		{
 			name: "error finding meeting times",
 			setupMock: func() {
-				user.User = &store.User{Remote: &remote.User{ID: "testRemoteUserID"}}
-				mockPluginAPI.EXPECT().GetMattermostUser("testMMUserID")
+				user.User = &store.User{Remote: &remote.User{ID: MockRemoteUserID}}
+				mockPluginAPI.EXPECT().GetMattermostUser(MockMMUserID)
 				mockClient.EXPECT().FindMeetingTimes(user.User.Remote.ID, meetingParams).Return(nil, errors.New("finding times error")).Times(1)
 			},
 			assertions: func(t *testing.T, err error, results *remote.MeetingTimeSuggestionResults) {
@@ -374,8 +374,8 @@ func TestFindMeetingTimes(t *testing.T) {
 		{
 			name: "successful meeting time retrieval",
 			setupMock: func() {
-				user.User = &store.User{Remote: &remote.User{ID: "testRemoteUserID"}}
-				mockPluginAPI.EXPECT().GetMattermostUser("testMMUserID")
+				user.User = &store.User{Remote: &remote.User{ID: MockRemoteUserID}}
+				mockPluginAPI.EXPECT().GetMattermostUser(MockMMUserID)
 				mockClient.EXPECT().FindMeetingTimes(user.User.Remote.ID, meetingParams).Return(&remote.MeetingTimeSuggestionResults{}, nil).Times(1)
 			},
 			assertions: func(t *testing.T, err error, results *remote.MeetingTimeSuggestionResults) {
@@ -407,7 +407,7 @@ func TestGetCalendars(t *testing.T) {
 		{
 			name: "error filtering with client",
 			setupMock: func() {
-				mockStore.EXPECT().LoadUser("testMMUserID").Return(nil, errors.New("error loading the user")).Times(1)
+				mockStore.EXPECT().LoadUser(MockMMUserID).Return(nil, errors.New("error loading the user")).Times(1)
 			},
 			assertions: func(t *testing.T, err error, calendars []*remote.Calendar) {
 				require.Error(t, err)
@@ -418,8 +418,8 @@ func TestGetCalendars(t *testing.T) {
 		{
 			name: "error getting calendars",
 			setupMock: func() {
-				user.User = &store.User{Remote: &remote.User{ID: "testRemoteUserID"}}
-				mockPluginAPI.EXPECT().GetMattermostUser("testMMUserID")
+				user.User = &store.User{Remote: &remote.User{ID: MockRemoteUserID}}
+				mockPluginAPI.EXPECT().GetMattermostUser(MockMMUserID)
 				mockClient.EXPECT().GetCalendars(user.User.Remote.ID).Return(nil, errors.New("getting calendars error")).Times(1)
 			},
 			assertions: func(t *testing.T, err error, calendars []*remote.Calendar) {
@@ -431,8 +431,8 @@ func TestGetCalendars(t *testing.T) {
 		{
 			name: "successful calendars retrieval",
 			setupMock: func() {
-				user.User = &store.User{Remote: &remote.User{ID: "testRemoteUserID"}}
-				mockPluginAPI.EXPECT().GetMattermostUser("testMMUserID")
+				user.User = &store.User{Remote: &remote.User{ID: MockRemoteUserID}}
+				mockPluginAPI.EXPECT().GetMattermostUser(MockMMUserID)
 				mockClient.EXPECT().GetCalendars(user.User.Remote.ID).Return([]*remote.Calendar{{ID: "calendar1"}}, nil).Times(1)
 			},
 			assertions: func(t *testing.T, err error, calendars []*remote.Calendar) {

--- a/calendar/engine/calendar_test.go
+++ b/calendar/engine/calendar_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestViewCalendar(t *testing.T) {
-	mscalendar, mockStore, _, _, _, mockClient, _ := MockSetup(t)
-
+	mscalendar, mockStore, _, _, _, mockClient, _ := GetMockSetup(t)
 	now := time.Now()
 	from := now.Add(-time.Hour)
 	to := now.Add(time.Hour)
@@ -30,11 +29,7 @@ func TestViewCalendar(t *testing.T) {
 	}{
 		{
 			name: "error filtering with client",
-			user: &User{
-				User:             nil,
-				MattermostUser:   &model.User{Id: "testMMID"},
-				MattermostUserID: "testMMUserID",
-			},
+			user: GetMockUser(nil, model.NewString(MockMMModelUserID), MockMMUserID),
 			setupMock: func() {
 				mockStore.EXPECT().LoadUser("testMMUserID").Return(nil, errors.New("error loading the user")).Times(1)
 			},
@@ -45,11 +40,7 @@ func TestViewCalendar(t *testing.T) {
 		},
 		{
 			name: "error getting calendar view",
-			user: &User{
-				User:             &store.User{Remote: &remote.User{ID: "testRemoteUserID"}},
-				MattermostUser:   &model.User{Id: "testMMID"},
-				MattermostUserID: "testMMUserID",
-			},
+			user: GetMockUser(model.NewString(MockRemoteUserID), model.NewString(MockMMModelUserID), MockMMUserID),
 			setupMock: func() {
 				mockClient.EXPECT().GetDefaultCalendarView("testRemoteUserID", from, to).Return(nil, fmt.Errorf("error getting calendar view")).Times(1)
 			},
@@ -60,11 +51,7 @@ func TestViewCalendar(t *testing.T) {
 		},
 		{
 			name: "successful calendar view",
-			user: &User{
-				User:             &store.User{Remote: &remote.User{ID: "testRemoteUserID"}},
-				MattermostUser:   &model.User{Id: "testMMID"},
-				MattermostUserID: "testMMUserID",
-			},
+			user: GetMockUser(model.NewString(MockRemoteUserID), model.NewString(MockMMModelUserID), MockMMUserID),
 			setupMock: func() {
 				mockClient.EXPECT().GetDefaultCalendarView("testRemoteUserID", from, to).Return([]*remote.Event{{Subject: "Test Event"}}, nil).Times(1)
 			},
@@ -88,8 +75,7 @@ func TestViewCalendar(t *testing.T) {
 }
 
 func TestGetTodayCalendarEvents(t *testing.T) {
-	mscalendar, mockStore, _, _, _, mockClient, _ := MockSetup(t)
-
+	mscalendar, mockStore, _, _, _, mockClient, _ := GetMockSetup(t)
 	now := time.Now()
 	timezone := "America/Los_Angeles"
 	from, to := getTodayHoursForTimezone(now, timezone)
@@ -102,11 +88,7 @@ func TestGetTodayCalendarEvents(t *testing.T) {
 	}{
 		{
 			name: "error expanding remote user",
-			user: &User{
-				User:             nil,
-				MattermostUser:   &model.User{Id: "testMMID"},
-				MattermostUserID: "testMMUserID",
-			},
+			user: GetMockUser(nil, model.NewString(MockMMModelUserID), MockMMUserID),
 			setupMock: func() {
 				mockStore.EXPECT().LoadUser("testMMUserID").Return(nil, errors.New("error loading the user")).Times(1)
 			},
@@ -117,11 +99,7 @@ func TestGetTodayCalendarEvents(t *testing.T) {
 		},
 		{
 			name: "error getting calendar view",
-			user: &User{
-				User:             &store.User{Remote: &remote.User{ID: "testRemoteUserID"}},
-				MattermostUser:   &model.User{Id: "testMMID"},
-				MattermostUserID: "testMMUserID",
-			},
+			user: GetMockUser(model.NewString(MockRemoteUserID), model.NewString(MockMMModelUserID), MockMMUserID),
 			setupMock: func() {
 				mockClient.EXPECT().GetDefaultCalendarView("testRemoteUserID", from, to).Return(nil, fmt.Errorf("error getting calendar view")).Times(1)
 			},
@@ -132,11 +110,7 @@ func TestGetTodayCalendarEvents(t *testing.T) {
 		},
 		{
 			name: "successful calendar view",
-			user: &User{
-				User:             &store.User{Remote: &remote.User{ID: "testRemoteUserID"}},
-				MattermostUser:   &model.User{Id: "testMMID"},
-				MattermostUserID: "testMMUserID",
-			},
+			user: GetMockUser(model.NewString(MockRemoteUserID), model.NewString(MockMMModelUserID), MockMMUserID),
 			setupMock: func() {
 				mockClient.EXPECT().GetDefaultCalendarView("testRemoteUserID", from, to).Return([]*remote.Event{{Subject: "Today's Test Event"}}, nil).Times(1)
 			},
@@ -160,7 +134,7 @@ func TestGetTodayCalendarEvents(t *testing.T) {
 }
 
 func TestCreateCalendar(t *testing.T) {
-	mscalendar, mockStore, _, _, _, mockClient, _ := MockSetup(t)
+	mscalendar, mockStore, _, _, _, mockClient, _ := GetMockSetup(t)
 
 	tests := []struct {
 		name       string
@@ -170,13 +144,9 @@ func TestCreateCalendar(t *testing.T) {
 		assertions func(t *testing.T, createdCalendar *remote.Calendar, err error)
 	}{
 		{
-			name: "error expanding user",
-			user: &User{
-				MattermostUserID: "testMMUserID",
-			},
-			calendar: &remote.Calendar{
-				Name: "Test Calendar",
-			},
+			name:     "error expanding user",
+			user:     GetMockUser(nil, nil, MockMMUserID),
+			calendar: GetMockCalendar(MockCalendarName),
 			setupMock: func() {
 				mockStore.EXPECT().LoadUser("testMMUserID").Return(nil, errors.New("error loading the user")).Times(1)
 			},
@@ -186,15 +156,9 @@ func TestCreateCalendar(t *testing.T) {
 			},
 		},
 		{
-			name: "error creating calendar",
-			user: &User{
-				User:             &store.User{Remote: &remote.User{ID: "testRemoteUserID"}},
-				MattermostUser:   &model.User{Id: "testMMUserID"},
-				MattermostUserID: "testMMUserID",
-			},
-			calendar: &remote.Calendar{
-				Name: "Test Calendar",
-			},
+			name:     "error creating calendar",
+			user:     GetMockUser(model.NewString(MockRemoteUserID), model.NewString(MockMMModelUserID), MockMMUserID),
+			calendar: GetMockCalendar(MockCalendarName),
 			setupMock: func() {
 				mockClient.EXPECT().CreateCalendar("testRemoteUserID", &remote.Calendar{Name: "Test Calendar"}).Return(nil, fmt.Errorf("error creating calendar")).Times(1)
 			},
@@ -204,15 +168,9 @@ func TestCreateCalendar(t *testing.T) {
 			},
 		},
 		{
-			name: "successful calendar creation",
-			user: &User{
-				User:             &store.User{Remote: &remote.User{ID: "testRemoteUserID"}},
-				MattermostUser:   &model.User{Id: "testMMUserID"},
-				MattermostUserID: "testMMUserID",
-			},
-			calendar: &remote.Calendar{
-				Name: "Test Calendar",
-			},
+			name:     "successful calendar creation",
+			user:     GetMockUser(model.NewString(MockRemoteUserID), model.NewString(MockMMModelUserID), MockMMUserID),
+			calendar: GetMockCalendar(MockCalendarName),
 			setupMock: func() {
 				mockClient.EXPECT().CreateCalendar("testRemoteUserID", &remote.Calendar{Name: "Test Calendar"}).Return(&remote.Calendar{Name: "Created Test Calendar"}, nil).Times(1)
 			},
@@ -233,7 +191,7 @@ func TestCreateCalendar(t *testing.T) {
 }
 
 func TestCreateEvent(t *testing.T) {
-	mscalendar, mockStore, mockPoster, _, mockPluginAPI, mockClient, mockLogger := MockSetup(t)
+	mscalendar, mockStore, mockPoster, _, mockPluginAPI, mockClient, mockLogger := GetMockSetup(t)
 
 	tests := []struct {
 		name          string
@@ -244,11 +202,9 @@ func TestCreateEvent(t *testing.T) {
 		expectedEvent *remote.Event
 	}{
 		{
-			name: "error expanding user",
-			user: &User{
-				MattermostUserID: "testMMUserID",
-			},
-			event: &remote.Event{Subject: "Test Event"},
+			name:  "error expanding user",
+			user:  GetMockUser(nil, nil, MockMMUserID),
+			event: GetMockEvent(MockEventName, nil, nil, nil, nil),
 			setupMock: func() {
 				mockStore.EXPECT().LoadUser("testMMUserID").Return(nil, errors.New("error loading the user")).Times(1)
 			},
@@ -258,12 +214,9 @@ func TestCreateEvent(t *testing.T) {
 			},
 		},
 		{
-			name: "error creating direct message",
-			user: &User{
-				User:             &store.User{Remote: &remote.User{ID: "testRemoteUserID"}},
-				MattermostUserID: "testMMUserID",
-			},
-			event: &remote.Event{Subject: "Test Event"},
+			name:  "error creating direct message",
+			user:  GetMockUser(model.NewString(MockRemoteUserID), nil, MockMMUserID),
+			event: GetMockEvent(MockEventName, nil, nil, nil, nil),
 			setupMock: func() {
 				mockStore.EXPECT().LoadUser("testMMUserID").Return(nil, errors.New("not found")).Times(1)
 				mockPluginAPI.EXPECT().GetMattermostUser("testMMUserID")
@@ -278,12 +231,9 @@ func TestCreateEvent(t *testing.T) {
 			},
 		},
 		{
-			name: "error creating event",
-			user: &User{
-				User:             &store.User{Remote: &remote.User{ID: "testRemoteUserID"}},
-				MattermostUserID: "testMMUserID",
-			},
-			event: &remote.Event{Subject: "Test Event"},
+			name:  "error creating event",
+			user:  GetMockUser(model.NewString(MockRemoteUserID), nil, MockMMUserID),
+			event: GetMockEvent(MockEventName, nil, nil, nil, nil),
 			setupMock: func() {
 				mockStore.EXPECT().LoadUser("testMMUserID").Return(nil, errors.New("not found")).Times(1)
 				mockPluginAPI.EXPECT().GetMattermostUser("testMMUserID")
@@ -297,17 +247,14 @@ func TestCreateEvent(t *testing.T) {
 		},
 		{
 			name: "successful event creation",
-			user: &User{
-				User:             &store.User{Remote: &remote.User{ID: "testRemoteUserID"}},
-				MattermostUserID: "testMMUserID",
-			},
-			event: &remote.Event{
-				Subject:   "Test Event",
-				Location:  &remote.Location{DisplayName: "Test Location"},
-				Start:     &remote.DateTime{DateTime: "2024-10-01T09:00:00", TimeZone: "UTC"},
-				End:       &remote.DateTime{DateTime: "2024-10-01T10:00:00", TimeZone: "UTC"},
-				Attendees: []*remote.Attendee{{EmailAddress: &remote.EmailAddress{Address: "attendee1@example.com"}}},
-			},
+			user: GetMockUser(model.NewString(MockRemoteUserID), nil, MockMMUserID),
+			event: GetMockEvent(
+				MockEventName,
+				&remote.Location{DisplayName: "Test Location"},
+				&remote.DateTime{DateTime: "2024-10-01T09:00:00", TimeZone: "UTC"},
+				&remote.DateTime{DateTime: "2024-10-01T10:00:00", TimeZone: "UTC"},
+				[]*remote.Attendee{{EmailAddress: &remote.EmailAddress{Address: "attendee1@example.com"}}},
+			),
 			setupMock: func() {
 				mockStore.EXPECT().LoadUser("testMMUserID").Return(nil, errors.New("not found")).Times(1)
 				mockPluginAPI.EXPECT().GetMattermostUser("testMMUserID")
@@ -337,23 +284,17 @@ func TestCreateEvent(t *testing.T) {
 }
 
 func TestDeleteCalendar(t *testing.T) {
-	mscalendar, mockStore, _, _, mockPluginAPI, mockClient, _ := MockSetup(t)
-
-	user := &User{
-		MattermostUserID: "testMMUserID",
-	}
+	mscalendar, mockStore, _, _, mockPluginAPI, mockClient, _ := GetMockSetup(t)
+	user := GetMockUser(nil, nil, MockMMUserID)
 
 	tests := []struct {
 		name       string
-		calendarID string
 		setupMock  func()
 		assertions func(t *testing.T, err error)
 	}{
 		{
-			name:       "error filtering with client",
-			calendarID: "testCalendarID",
+			name: "error filtering with client",
 			setupMock: func() {
-				user.User = nil
 				mockStore.EXPECT().LoadUser("testMMUserID").Return(nil, errors.New("error loading the user")).Times(1)
 			},
 			assertions: func(t *testing.T, err error) {
@@ -362,8 +303,7 @@ func TestDeleteCalendar(t *testing.T) {
 			},
 		},
 		{
-			name:       "error deleting calendar",
-			calendarID: "testCalendarID",
+			name: "error deleting calendar",
 			setupMock: func() {
 				user.User = &store.User{Remote: &remote.User{ID: "testRemoteUserID"}}
 				mockPluginAPI.EXPECT().GetMattermostUser("testMMUserID")
@@ -375,11 +315,9 @@ func TestDeleteCalendar(t *testing.T) {
 			},
 		},
 		{
-			name:       "successful calendar deletion",
-			calendarID: "testCalendarID",
+			name: "successful calendar deletion",
 			setupMock: func() {
 				mockPluginAPI.EXPECT().GetMattermostUser("testMMUserID")
-				user.User = &store.User{Remote: &remote.User{ID: "testRemoteUserID"}}
 				mockClient.EXPECT().DeleteCalendar(user.User.Remote.ID, "testCalendarID").Return(nil).Times(1)
 			},
 			assertions: func(t *testing.T, err error) {
@@ -391,7 +329,7 @@ func TestDeleteCalendar(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.setupMock()
 
-			err := mscalendar.DeleteCalendar(user, tt.calendarID)
+			err := mscalendar.DeleteCalendar(user, MockCalendarID)
 
 			tt.assertions(t, err)
 		})
@@ -399,11 +337,8 @@ func TestDeleteCalendar(t *testing.T) {
 }
 
 func TestFindMeetingTimes(t *testing.T) {
-	mscalendar, mockStore, _, _, mockPluginAPI, mockClient, _ := MockSetup(t)
-
-	user := &User{
-		MattermostUserID: "testMMUserID",
-	}
+	mscalendar, mockStore, _, _, mockPluginAPI, mockClient, _ := GetMockSetup(t)
+	user := GetMockUser(nil, nil, MockMMUserID)
 
 	meetingParams := &remote.FindMeetingTimesParameters{}
 
@@ -461,11 +396,8 @@ func TestFindMeetingTimes(t *testing.T) {
 }
 
 func TestGetCalendars(t *testing.T) {
-	mscalendar, mockStore, _, _, mockPluginAPI, mockClient, _ := MockSetup(t)
-
-	user := &User{
-		MattermostUserID: "testMMUserID",
-	}
+	mscalendar, mockStore, _, _, mockPluginAPI, mockClient, _ := GetMockSetup(t)
+	user := GetMockUser(nil, nil, MockMMUserID)
 
 	tests := []struct {
 		name       string

--- a/calendar/engine/calendar_test.go
+++ b/calendar/engine/calendar_test.go
@@ -604,6 +604,7 @@ func MockSetup(t *testing.T) (*mscalendar, *mock_store.MockStore, *mock_bot.Mock
 			DisplayName:    "testDisplayName",
 			CommandTrigger: "testCommandTrigger",
 		},
+		PluginVersion: "1.0.0",
 	}
 
 	return mscalendar, mockStore, mockPoster, mockRemote, mockPluginAPI, mockClient, mockLogger

--- a/calendar/engine/calendar_test.go
+++ b/calendar/engine/calendar_test.go
@@ -8,13 +8,8 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
 
-	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/config"
-	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/engine/mock_plugin_api"
 	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/remote"
-	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/remote/mock_remote"
 	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/store"
-	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/store/mock_store"
-	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/utils/bot/mock_bot"
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/stretchr/testify/require"
@@ -241,19 +236,19 @@ func TestCreateEvent(t *testing.T) {
 	mscalendar, mockStore, mockPoster, _, mockPluginAPI, mockClient, mockLogger := MockSetup(t)
 
 	tests := []struct {
-		name              string
-		user              *User
-		event             *remote.Event
-		setupMock         func()
-		assertions        func(t *testing.T, createdEvent *remote.Event, err error)
-		expectedEvent     *remote.Event
+		name          string
+		user          *User
+		event         *remote.Event
+		setupMock     func()
+		assertions    func(t *testing.T, createdEvent *remote.Event, err error)
+		expectedEvent *remote.Event
 	}{
 		{
 			name: "error expanding user",
 			user: &User{
 				MattermostUserID: "testMMUserID",
 			},
-			event:             &remote.Event{Subject: "Test Event"},
+			event: &remote.Event{Subject: "Test Event"},
 			setupMock: func() {
 				mockStore.EXPECT().LoadUser("testMMUserID").Return(nil, errors.New("error loading the user")).Times(1)
 			},
@@ -268,7 +263,7 @@ func TestCreateEvent(t *testing.T) {
 				User:             &store.User{Remote: &remote.User{ID: "testRemoteUserID"}},
 				MattermostUserID: "testMMUserID",
 			},
-			event:             &remote.Event{Subject: "Test Event"},
+			event: &remote.Event{Subject: "Test Event"},
 			setupMock: func() {
 				mockStore.EXPECT().LoadUser("testMMUserID").Return(nil, errors.New("not found")).Times(1)
 				mockPluginAPI.EXPECT().GetMattermostUser("testMMUserID")
@@ -288,7 +283,7 @@ func TestCreateEvent(t *testing.T) {
 				User:             &store.User{Remote: &remote.User{ID: "testRemoteUserID"}},
 				MattermostUserID: "testMMUserID",
 			},
-			event:             &remote.Event{Subject: "Test Event"},
+			event: &remote.Event{Subject: "Test Event"},
 			setupMock: func() {
 				mockStore.EXPECT().LoadUser("testMMUserID").Return(nil, errors.New("not found")).Times(1)
 				mockPluginAPI.EXPECT().GetMattermostUser("testMMUserID")
@@ -523,42 +518,4 @@ func TestGetCalendars(t *testing.T) {
 			tt.assertions(t, err, calendars)
 		})
 	}
-}
-
-// revive:disable:unexported-return
-func MockSetup(t *testing.T) (*mscalendar, *mock_store.MockStore, *mock_bot.MockPoster, *mock_remote.MockRemote, *mock_plugin_api.MockPluginAPI, *mock_remote.MockClient, *mock_bot.MockLogger) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mockStore := mock_store.NewMockStore(ctrl)
-	mockPoster := mock_bot.NewMockPoster(ctrl)
-	mockRemote := mock_remote.NewMockRemote(ctrl)
-	mockPluginAPI := mock_plugin_api.NewMockPluginAPI(ctrl)
-	mockClient := mock_remote.NewMockClient(ctrl)
-	mockLogger := mock_bot.NewMockLogger(ctrl)
-
-	env := Env{
-		Dependencies: &Dependencies{
-			Store:     mockStore,
-			Poster:    mockPoster,
-			Remote:    mockRemote,
-			PluginAPI: mockPluginAPI,
-			Logger:    mockLogger,
-		},
-	}
-
-	mscalendar := &mscalendar{
-		Env:    env,
-		client: mockClient,
-	}
-
-	mscalendar.Config = &config.Config{
-		Provider: config.ProviderConfig{
-			DisplayName:    "testDisplayName",
-			CommandTrigger: "testCommandTrigger",
-		},
-		PluginVersion: "1.0.0",
-	}
-
-	return mscalendar, mockStore, mockPoster, mockRemote, mockPluginAPI, mockClient, mockLogger
 }

--- a/calendar/engine/mock_test_setup.go
+++ b/calendar/engine/mock_test_setup.go
@@ -1,0 +1,51 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+
+	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/config"
+	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/engine/mock_plugin_api"
+	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/remote/mock_remote"
+	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/store/mock_store"
+	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/utils/bot/mock_bot"
+)
+
+// revive:disable:unexported-return
+func MockSetup(t *testing.T) (*mscalendar, *mock_store.MockStore, *mock_bot.MockPoster, *mock_remote.MockRemote, *mock_plugin_api.MockPluginAPI, *mock_remote.MockClient, *mock_bot.MockLogger) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := mock_store.NewMockStore(ctrl)
+	mockPoster := mock_bot.NewMockPoster(ctrl)
+	mockRemote := mock_remote.NewMockRemote(ctrl)
+	mockPluginAPI := mock_plugin_api.NewMockPluginAPI(ctrl)
+	mockClient := mock_remote.NewMockClient(ctrl)
+	mockLogger := mock_bot.NewMockLogger(ctrl)
+
+	env := Env{
+		Dependencies: &Dependencies{
+			Store:     mockStore,
+			Poster:    mockPoster,
+			Remote:    mockRemote,
+			PluginAPI: mockPluginAPI,
+			Logger:    mockLogger,
+		},
+	}
+
+	mscalendar := &mscalendar{
+		Env:    env,
+		client: mockClient,
+	}
+
+	mscalendar.Config = &config.Config{
+		Provider: config.ProviderConfig{
+			DisplayName:    "testDisplayName",
+			CommandTrigger: "testCommandTrigger",
+		},
+		PluginVersion: "1.0.0",
+	}
+
+	return mscalendar, mockStore, mockPoster, mockRemote, mockPluginAPI, mockClient, mockLogger
+}

--- a/calendar/engine/mock_test_setup.go
+++ b/calendar/engine/mock_test_setup.go
@@ -7,13 +7,28 @@ import (
 
 	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/config"
 	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/engine/mock_plugin_api"
+	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/remote"
 	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/remote/mock_remote"
+	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/store"
 	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/store/mock_store"
 	"github.com/mattermost/mattermost-plugin-mscalendar/calendar/utils/bot/mock_bot"
+
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+const (
+	MockRemoteUserID  = "testRemoteUserID"
+	MockMMModelUserID = "testMMID"
+	MockMMUserID      = "testMMUserID"
+
+	MockCalendarName = "Test Calendar"
+	MockCalendarID   = "testCalendarID"
+
+	MockEventName = "Test Event"
 )
 
 // revive:disable:unexported-return
-func MockSetup(t *testing.T) (*mscalendar, *mock_store.MockStore, *mock_bot.MockPoster, *mock_remote.MockRemote, *mock_plugin_api.MockPluginAPI, *mock_remote.MockClient, *mock_bot.MockLogger) {
+func GetMockSetup(t *testing.T) (*mscalendar, *mock_store.MockStore, *mock_bot.MockPoster, *mock_remote.MockRemote, *mock_plugin_api.MockPluginAPI, *mock_remote.MockClient, *mock_bot.MockLogger) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -48,4 +63,38 @@ func MockSetup(t *testing.T) (*mscalendar, *mock_store.MockStore, *mock_bot.Mock
 	}
 
 	return mscalendar, mockStore, mockPoster, mockRemote, mockPluginAPI, mockClient, mockLogger
+}
+
+func GetMockUser(remoteUserID, mmModelUserID *string, mmUserID string) *User {
+	user := (*store.User)(nil)
+	if remoteUserID != nil {
+		user = &store.User{Remote: &remote.User{ID: *remoteUserID}}
+	}
+
+	mmUser := (*model.User)(nil)
+	if mmModelUserID != nil {
+		mmUser = &model.User{Id: *mmModelUserID}
+	}
+
+	return &User{
+		User:             user,
+		MattermostUser:   mmUser,
+		MattermostUserID: mmUserID,
+	}
+}
+
+func GetMockCalendar(name string) *remote.Calendar {
+	return &remote.Calendar{
+		Name: name,
+	}
+}
+
+func GetMockEvent(subject string, location *remote.Location, start, end *remote.DateTime, attendees []*remote.Attendee) *remote.Event {
+	return &remote.Event{
+		Subject:   subject,
+		Location:  location,
+		Start:     start,
+		End:       end,
+		Attendees: attendees,
+	}
 }

--- a/calendar/engine/test_utils.go
+++ b/calendar/engine/test_utils.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	MockRemoteUserID  = "testRemoteUserID"
-	MockMMModelUserID = "testMMID"
+	MockMMModelUserID = "testMMModelUserID"
 	MockMMUserID      = "testMMUserID"
 
 	MockCalendarName = "Test Calendar"


### PR DESCRIPTION
### Summary
[MM-836]: Added server test cases for engine/calendar.go file